### PR TITLE
docs: correct voucher command references in demo

### DIFF
--- a/demos/SDO-OH-EXF-dev-simple/README.md
+++ b/demos/SDO-OH-EXF-dev-simple/README.md
@@ -85,8 +85,8 @@ When the all-in-one Open Horizon instance is run in Step Two, it creates a local
 cd ../../..
 ```
 * Edit the `test-sdo.sh` script that came with the all-in-one Open Horizon install and change the following lines:
-    * Towards the end, the line: `hzn voucher import /var/sdo/voucher.json --policy node.policy.json`
-    * Adjust the path and name of the policy file to `hzn voucher import /var/sdo/voucher.json --policy orra/demos/SDO-OH-EXF-dev-simple/configuration/node.policy`
+    * Towards the end, the line: `hzn sdo voucher import /var/sdo/voucher.json --policy node.policy.json`
+    * Adjust the path and name of the policy file to `hzn sdo voucher import /var/sdo/voucher.json --policy orra/demos/SDO-OH-EXF-dev-simple/configuration/node.policy`
     * A few lines later find this line: `/usr/sdo/bin/owner-boot-device ibm.helloworld`
     * Change the pattern from "ibm.helloworld" to `com.github.joewxboy.horizon.edgex`
 * Run the test script:


### PR DESCRIPTION
Update demo documentation to reflect the change in the test-sdo.sh script
from an `hzn voucher ...` command to an `hzn sdo voucher ...` command

Closes #7

Signed-off-by: Ben Zimmerman <ben.d.zimmerman@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
No behavior changes

## Issue Number:
#7 

## What is the new behavior?
No behavior changes

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
No
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information