### PR TITLE
feat: expose app ui port externally

### DIFF
--- a/demos/OH-EXF-Kamakura/src/app-camera-management/service.definition.json
+++ b/demos/OH-EXF-Kamakura/src/app-camera-management/service.definition.json
@@ -65,7 +65,7 @@
                     "${APP_BIND_HORIZON_DIR}/scripts/wait.sh:/wait.sh:ro"
                 ],
                 "ports": [{
-                    "HostIP": "127.0.0.1",
+                    "HostIP": "0.0.0.0",
                     "HostPort": "59750:59750/tcp"
                 }]
             }


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- N/A Tests for the changes have been added (for bug fixes / features)
- N/A Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
app-camera-mangement port 59750 only listens on localhost.


## Issue Number:


## What is the new behavior?
app-camera-mangement port 59750 listens on `0.0.0.0`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
No
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information